### PR TITLE
Fix pytest hanging issue by properly cleaning up async resources

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     "websockets>=15.0.1",
 ]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+
 [tool.mypy]
 allow_redefinition = true
 warn_unused_configs = true

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,10 +38,11 @@ TestingAsyncSessionLocal = async_sessionmaker(
 
 
 @pytest_asyncio.fixture(scope="session")
-def redis_connection():
+async def redis_connection():
     import fakeredis
     redis_connection = fakeredis.FakeAsyncRedis()
-    return redis_connection
+    yield redis_connection
+    await redis_connection.aclose()
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
@@ -51,6 +52,7 @@ async def cleanup_db():
     yield 
     async with async_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+    await async_engine.dispose()
 
 
 @pytest_asyncio.fixture(scope="session")


### PR DESCRIPTION
- Convert redis_connection fixture to async and add aclose() cleanup
- Add async_engine.dispose() in cleanup_db fixture teardown
- Configure pytest-asyncio with auto mode and session-scoped event loop
- Resolves issue #2 : pytest now terminates properly after all tests complete